### PR TITLE
자바 옵저버 api 지원 문제 해결

### DIFF
--- a/src/module/snakegame/KeyListener.java
+++ b/src/module/snakegame/KeyListener.java
@@ -5,11 +5,14 @@ import com.github.kwhat.jnativehook.NativeHookException;
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
 import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
 
-import java.util.Observable;
+//import java.util.Observable;
 
-public class KeyListener  extends Observable implements NativeKeyListener {
-    private static int lastKeyCode;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class KeyListener implements NativeKeyListener {
     private static KeyListener instance;
+    private final List<Observer> observers = new CopyOnWriteArrayList<>();
 
     // private 생성자로 외부에서의 인스턴스 생성 방지
     private KeyListener() {
@@ -31,25 +34,26 @@ public class KeyListener  extends Observable implements NativeKeyListener {
         return instance;
     }
 
-//    public KeyListener() {
-//        try {
-//            // JNativeHook 라이브러리 초기화 및 등록
-//            GlobalScreen.registerNativeHook();
-//        } catch (NativeHookException ex) {
-//            System.err.println("There was a problem registering the native hook.");
-//            System.err.println(ex.getMessage());
-//            System.exit(1);
-//        }
-//
-//        // 이벤트 리스너 등록
-//        GlobalScreen.addNativeKeyListener(this);
-//    }
+    // 옵저버 추가
+    public void addObserver(Observer observer) {
+        observers.add(observer);
+    }
+
+    //옵저버 제거
+    public void removeObserver(Observer observer) {
+        observers.remove(observer);
+    }
+
+    // 옵저버에게 알림 전달
+    private void notifyObservers(Object arg) {
+        for (Observer observer : observers) {
+            observer.update(arg);
+        }
+    }
 
     @Override
     public void nativeKeyPressed(NativeKeyEvent e) {
-        lastKeyCode = e.getKeyCode();
-        setChanged();
-        notifyObservers(lastKeyCode);
+        notifyObservers(e.getKeyCode());
     }
 
     @Override

--- a/src/module/snakegame/Observer.java
+++ b/src/module/snakegame/Observer.java
@@ -1,0 +1,5 @@
+package module.snakegame;
+
+public interface Observer {
+    void update(Object arg);
+}

--- a/src/module/snakegame/SnakeGameProcess.java
+++ b/src/module/snakegame/SnakeGameProcess.java
@@ -1,10 +1,7 @@
 package module.snakegame;
 
-import com.github.kwhat.jnativehook.NativeHookException;
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.util.*;
 
 public class SnakeGameProcess implements Observer {
@@ -37,29 +34,27 @@ public class SnakeGameProcess implements Observer {
     private boolean isSpeedGame = true;
 
     @Override
-    public void update(Observable o, Object arg) {
-        if (o instanceof KeyListener) {
-            int keyCode = (int) arg;
+    public void update(Object arg) {
+        int keyCode = (int) arg;
 
-            if(keyCode == NativeKeyEvent.VC_UP && !direction.equals("DOWN")){
-                direction = "UP";
-            }
-            if(keyCode == NativeKeyEvent.VC_DOWN && !direction.equals("UP")){
-                direction = "DOWN";
-            }
-            if(keyCode == NativeKeyEvent.VC_LEFT && !direction.equals("RIGHT")){
-                direction = "LEFT";
-            }
-            if(keyCode == NativeKeyEvent.VC_RIGHT && !direction.equals("LEFT")){
-                direction = "RIGHT";
-            }
-            if(keyCode == NativeKeyEvent.VC_ESCAPE){
-                isUpdateGui = false;
-                isSpeedGame = false;
+        if(keyCode == NativeKeyEvent.VC_UP && !direction.equals("DOWN")){
+            direction = "UP";
+        }
+        if(keyCode == NativeKeyEvent.VC_DOWN && !direction.equals("UP")){
+            direction = "DOWN";
+        }
+        if(keyCode == NativeKeyEvent.VC_LEFT && !direction.equals("RIGHT")){
+            direction = "LEFT";
+        }
+        if(keyCode == NativeKeyEvent.VC_RIGHT && !direction.equals("LEFT")){
+            direction = "RIGHT";
+        }
+        if(keyCode == NativeKeyEvent.VC_ESCAPE){
+            isUpdateGui = false;
+            isSpeedGame = false;
 
-                System.out.println("ESC key pressed. Exiting...");
-                keyListener.removeHook();
-            }
+            System.out.println("ESC key pressed. Exiting...");
+            keyListener.removeHook();
         }
     }
 
@@ -312,6 +307,7 @@ public class SnakeGameProcess implements Observer {
         fruit[0] = fruitX;
         fruit[1] = fruitY;
     }
+
 
 
 }


### PR DESCRIPTION
자바 옵저버 api가 버전 9 이후로 지원을 하지 않기에
직접 옵저버를 구현해서 대체하였습니다